### PR TITLE
changing res.json(obj,status) to res.status(status).json(obj)

### DIFF
--- a/lib/json-api-response.js
+++ b/lib/json-api-response.js
@@ -111,7 +111,7 @@ var jar = function(){
             });
 
             self.res.set('Content-Type', 'application/json');
-            self.res.json( status, JSON.parse( out ) );
+            self.res.status( status ).json( JSON.parse( out ) );
             return null;
         }
         else{


### PR DESCRIPTION
Hi, just want to update this, since I hate to see deprecated notice on my console.
